### PR TITLE
Add support for Rx/Ry/Rz gates

### DIFF
--- a/bloch_sphere/animate_bloch.py
+++ b/bloch_sphere/animate_bloch.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 import dataclasses
 import argparse
+import re
 import sys
 import numpy as np
 
@@ -141,6 +142,15 @@ class AnimState:
                 except ValueError:
                     print(f'Error: Custom gate arguments contain invalid '
                           f'floats {gate}.')
+                continue
+            if re.match('R[x,y,z][,;]', gate[:3]):
+                try:
+                    x, y, z = gate[1] == 'x', gate[1] == 'y', gate[1] == 'z' 
+                    r_pi = float(gate[3:])
+                    label = f"{gate[:2]}({r_pi:.3f}".rstrip('0').rstrip('.') + ")"
+                    self.custom_gate(x, y, z, r_pi, label=label)
+                except ValueError:
+                    print('Error: Rx/Ry/Rz gate should have style like Rx;{float} or Rx,{float}.')
                 continue
             gate = gate.replace('-', '_')
             if gate in block_gates:

--- a/bloch_sphere/animate_bloch.py
+++ b/bloch_sphere/animate_bloch.py
@@ -150,7 +150,7 @@ class AnimState:
                 except ValueError:
                     print('Error: Rx/Ry/Rz gate should have style like '
                           'Rx;{float} or Rx,{float}.')
-                gate_name = gate[:3].lower()
+                gate_name = 'R' + gate[1].lower()  # Display Rx instead of rx
                 x = int(gate_name[1] == 'x')
                 y = int(gate_name[1] == 'y')
                 z = int(gate_name[1] == 'z') 

--- a/bloch_sphere/animate_bloch.py
+++ b/bloch_sphere/animate_bloch.py
@@ -155,7 +155,7 @@ class AnimState:
                 y = int(gate_name[1] == 'y')
                 z = int(gate_name[1] == 'z') 
                 formated_r_pi = f"{r_pi:.3f}".rstrip('0').rstrip('.')
-                label = f"{gate_name}({formated_r_pi})"
+                label = f"{gate_name}({formated_r_pi}π)"
                 self.custom_gate(x, y, z, r_pi, label=label)
                 continue
 

--- a/bloch_sphere/animate_bloch.py
+++ b/bloch_sphere/animate_bloch.py
@@ -143,15 +143,22 @@ class AnimState:
                     print(f'Error: Custom gate arguments contain invalid '
                           f'floats {gate}.')
                 continue
-            if re.match('R[x,y,z][,;]', gate[:3]):
+
+            if re.match('r[x,y,z][,;]', gate[:3].lower()):
                 try:
-                    x, y, z = gate[1] == 'x', gate[1] == 'y', gate[1] == 'z' 
                     r_pi = float(gate[3:])
-                    label = f"{gate[:2]}({r_pi:.3f}".rstrip('0').rstrip('.') + ")"
-                    self.custom_gate(x, y, z, r_pi, label=label)
                 except ValueError:
-                    print('Error: Rx/Ry/Rz gate should have style like Rx;{float} or Rx,{float}.')
+                    print('Error: Rx/Ry/Rz gate should have style like '
+                          'Rx;{float} or Rx,{float}.')
+                gate_name = gate[:3].lower()
+                x = int(gate_name[1] == 'x')
+                y = int(gate_name[1] == 'y')
+                z = int(gate_name[1] == 'z') 
+                formated_r_pi = f"{r_pi:.3f}".rstrip('0').rstrip('.')
+                label = f"{gate_name}({formated_r_pi})"
+                self.custom_gate(x, y, z, r_pi, label=label)
                 continue
+
             gate = gate.replace('-', '_')
             if gate in block_gates:
                 print(f'Error: Invalid gate name "{gate}".')

--- a/bloch_sphere/animate_bloch.py
+++ b/bloch_sphere/animate_bloch.py
@@ -153,7 +153,7 @@ class AnimState:
                 gate_name = 'R' + gate[1].lower()  # Display Rx instead of rx
                 x = int(gate_name[1] == 'x')
                 y = int(gate_name[1] == 'y')
-                z = int(gate_name[1] == 'z') 
+                z = int(gate_name[1] == 'z')
                 formated_r_pi = f"{r_pi:.3f}".rstrip('0').rstrip('.')
                 label = f"{gate_name}({formated_r_pi})"
                 self.custom_gate(x, y, z, r_pi, label=label)


### PR DESCRIPTION
It is common to use Rx/Ry/Rz + some rotation degree. However, in current API, either there is known gates like `X,Y,Z,S,T,V`...., or you have to call customer gates like `customer,1,0,0,0.25,label`. 

We should be able to simply call the rotation like`animate_bloch rz 'Rz,-0.25'`.